### PR TITLE
Fix fallback theme logic and enable custom theme registration

### DIFF
--- a/core/custom_themes.py
+++ b/core/custom_themes.py
@@ -5,13 +5,26 @@ import logging
 
 logger = logging.getLogger(__name__)
 
-def register_custom_themes():
+from user import USER_THEMES
+from ttkbootstrap.style import ThemeDefinition
+
+
+def register_custom_themes() -> bool:
     """Register custom themes using ttkbootstrap style system"""
     try:
-        logger.info("Custom theme registration temporarily disabled")
-        # Let's get the basic toggle working first, then add custom themes
+        style = tb.Style()
+
+        for name, definition in USER_THEMES.items():
+            if name not in style.theme_names():
+                theme_def = ThemeDefinition(
+                    name=name,
+                    themetype=definition.get("type", "dark"),
+                    colors=definition.get("colors", {}),
+                )
+                style.register_theme(theme_def)
+        logger.info("Custom themes registered")
         return True
-        
+
     except Exception as e:
         logger.error(f"Custom theme registration failed: {e}")
         return False
@@ -35,5 +48,5 @@ def get_available_themes():
         "light": ["aj_lightly", "pulse", "flatly", "litera", "minty", "lumen"],
         "dark": ["aj_darkly", "darkly", "cyborg", "superhero", "solar"]
     }
-    
-    return standard_themes
+        return standard_themes
+

--- a/gui/tabbed_main_window.py
+++ b/gui/tabbed_main_window.py
@@ -15,7 +15,7 @@ from ttkbootstrap.dialogs import Messagebox
 from core.utils import load_user_theme
 from core.api import WeatherAPI
 from core.data_handler import WeatherDataHandler
-from core.custom_themes import register_custom_themes
+from core.custom_themes import register_custom_themes, get_fallback_theme
 from gui.components import ThemeComponent, WeatherInputComponent, WeatherDisplayComponent, SavedCitiesComponent, ForecastDisplayComponent
 
 class TabbedWeatherDashboard:
@@ -39,9 +39,12 @@ class TabbedWeatherDashboard:
         try:
             self.app = tb.Window(themename=self.current_theme)
         except Exception as e:
-            self.logger.warning(f"Failed to load custom theme {self.current_theme}, using default: {e}")
-            self.app = tb.Window(themename="aj_darkly")
-            self.current_theme = "aj_darkly"
+            fallback = get_fallback_theme(self.current_theme)
+            self.logger.warning(
+                f"Failed to load theme {self.current_theme}, falling back to {fallback}: {e}"
+            )
+            self.app = tb.Window(themename=fallback)
+            self.current_theme = fallback
         
         self.app.title("Advanced Weather Dashboard")
         self.app.geometry("1000x700")  # Increased from 800x600


### PR DESCRIPTION
## Summary
- register custom themes using ttkbootstrap
- fall back to a default theme when `aj_darkly` isn't available

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_686db2f50d5c832c99215e2222c61324