### PR TITLE
Fix theme logging

### DIFF
--- a/gui/components/theme_component.py
+++ b/gui/components/theme_component.py
@@ -45,7 +45,7 @@ class ThemeComponent:
 
 
         # ✅ Confirm themes are loaded AFTER registration and before widget creation
-        print("Available themes:", style.theme_names())
+        logger.debug("Available themes: %s", style.theme_names())
 
 
         # Load auto theme settings

--- a/main.py
+++ b/main.py
@@ -16,6 +16,20 @@ import os
 from pathlib import Path
 from config import Config
 from gui.tabbed_main_window import TabbedWeatherDashboard
+from core.conversion_utils import (
+    add_numbers as _add_numbers_util,
+    convert_to_fahrenheit as _convert_to_fahrenheit_util,
+)
+
+
+def add_numbers(a: float, b: float) -> float:
+    """Expose simple addition for tests."""
+    return _add_numbers_util(a, b)
+
+
+def convert_to_fahrenheit(celsius: float) -> float:
+    """Expose Celsius to Fahrenheit conversion for tests."""
+    return _convert_to_fahrenheit_util(celsius)
 
 
 def setup_logging(config: Config):


### PR DESCRIPTION
## Summary
- log theme availability with logger.debug instead of print
- export math and conversion helpers from `main.py`

## Testing
- `pytest -q` *(fails: no display name and WeatherAPI issues)*

------
https://chatgpt.com/codex/tasks/task_b_68740d6762ac832c881d9631529d0d9a